### PR TITLE
Allow Symfony 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,17 +21,17 @@
     },
     "require": {
         "php": ">=8.1",
-        "symfony/console": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/twig-bundle": "^7.0"
+        "symfony/console": "^6.4|^7.0",
+        "symfony/filesystem": "^6.4|^7.0",
+        "symfony/twig-bundle": "^6.4|^7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",
-        "symfony/asset-mapper": "^7.0",
-        "symfony/browser-kit": "^7.0",
-        "symfony/css-selector": "^7.0",
-        "symfony/framework-bundle": "^7.0",
-        "symfony/phpunit-bridge": "^7.0",
+        "symfony/asset-mapper": "^6.4|^7.0",
+        "symfony/browser-kit": "^6.4|^7.0",
+        "symfony/css-selector": "^6.4|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/phpunit-bridge": "^6.4|^7.0",
         "symfony/stimulus-bundle": "^2.16",
         "symfony/ux-live-component": "^2.16",
         "symfony/ux-twig-component": "2.16",


### PR DESCRIPTION
There is no need to require Symfony packages >= 7.0, it also works fine with 6.4.