### PR TITLE
Fix embedded Live Component rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ copy.
 Then run the tests with:
 
 ```shell
-./scripts/test-app.sh
+./scripts/test-sandbox.sh
 ```
 
 #### Updating template stories

--- a/sandbox/templates/components/LiveComponent.stories.js
+++ b/sandbox/templates/components/LiveComponent.stories.js
@@ -1,11 +1,9 @@
 import LiveComponent from './LiveComponent.html.twig';
 import { userEvent, expect, fn, waitFor, within } from '@storybook/test';
+import {twig} from "@sensiolabs/storybook-symfony-webpack5";
 
 export default {
-    component: LiveComponent
-}
-
-export const Default = {
+    component: LiveComponent,
     args: {
         onClick: fn()
     },
@@ -21,4 +19,16 @@ export const Default = {
         await userEvent.click(button);
         await waitFor(() => expect(args.onClick).toHaveBeenCalledOnce());
     }
+}
+
+export const Default = {
+}
+
+export const EmbeddedRender = {
+    render: () => ({
+       components: {LiveComponent},
+       template: twig`
+        <twig:LiveComponent data-storybook-callbacks="{{ onClick }}">
+        </twig:LiveComponent>`
+    }),
 }

--- a/src/Controller/StorybookController.php
+++ b/src/Controller/StorybookController.php
@@ -23,17 +23,22 @@ final class StorybookController
 
     public function __invoke(Request $request, string $story): Response
     {
-        $request = RequestAttributesHelper::withStorybookAttributes($request, ['story' => $story]);
-
         $templateString = $request->getPayload()->get('template');
 
         if (null === $templateString) {
             throw new BadRequestHttpException('Missing "template" in request body.');
         }
 
+        $templateName = \sprintf('%s.html.twig', hash('xxh128', $templateString));
+
+        $request = RequestAttributesHelper::withStorybookAttributes($request, [
+            'story' => $story,
+            'template' => $templateName,
+        ]);
+
         $args = $this->argsProcessor->process($request);
 
-        $storyObj = new Story($story, $templateString, $args);
+        $storyObj = new Story($story, $templateName, $templateString, $args);
 
         $content = $this->storyRenderer->render($storyObj);
 

--- a/src/EventListener/ProxyRequestListener.php
+++ b/src/EventListener/ProxyRequestListener.php
@@ -31,6 +31,10 @@ final class ProxyRequestListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
+        if (!$event->isMainRequest() || 'storybook_render' === $request->attributes->get('_route')) {
+            return;
+        }
+
         if (!RequestAttributesHelper::isProxyRequest($request) || !$request->headers->has('referer')) {
             return;
         }

--- a/src/Story.php
+++ b/src/Story.php
@@ -6,6 +6,7 @@ final class Story
 {
     public function __construct(
         private readonly string $id,
+        private readonly string $templateName,
         private readonly string $template,
         private readonly Args $args,
     ) {
@@ -14,6 +15,11 @@ final class Story
     public function getId(): string
     {
         return $this->id;
+    }
+
+    public function getTemplateName(): string
+    {
+        return $this->templateName;
     }
 
     public function getTemplate(): string

--- a/src/Util/StorybookAttributes.php
+++ b/src/Util/StorybookAttributes.php
@@ -4,8 +4,13 @@ namespace Storybook\Util;
 
 final class StorybookAttributes
 {
+    private const REQUIRED_ATTRIBUTES = [
+        'story',
+    ];
+
     public function __construct(
         public readonly string $story,
+        public readonly ?string $template = null,
     ) {
     }
 
@@ -14,10 +19,15 @@ final class StorybookAttributes
      */
     public static function from(array $attributes): self
     {
-        if (!isset($attributes['story'])) {
-            throw new \InvalidArgumentException('Missing key "story" in attributes.');
+        foreach (self::REQUIRED_ATTRIBUTES as $attribute) {
+            if (!isset($attributes[$attribute])) {
+                throw new \InvalidArgumentException(\sprintf('Missing key "%s" in attributes.', $attribute));
+            }
         }
 
-        return new self(story: $attributes['story']);
+        return new self(
+            story: $attributes['story'],
+            template: $attributes['template'] ?? null,
+        );
     }
 }

--- a/tests/Integration/StoryRendererTest.php
+++ b/tests/Integration/StoryRendererTest.php
@@ -17,7 +17,7 @@ class StoryRendererTest extends KernelTestCase
         self::bootKernel();
 
         $renderer = static::getContainer()->get('storybook.story_renderer');
-        $story = new Story('story', $template, new Args());
+        $story = new Story('story', 'story.html.twig', $template, new Args());
 
         $this->expectException(UnauthorizedStoryException::class);
 
@@ -80,7 +80,7 @@ class StoryRendererTest extends KernelTestCase
         self::bootKernel();
 
         $renderer = static::getContainer()->get('storybook.story_renderer');
-        $story = new Story('story', $template, new Args($args));
+        $story = new Story('story', 'story.html.twig', $template, new Args($args));
 
         $content = $renderer->render($story);
 
@@ -169,7 +169,7 @@ class StoryRendererTest extends KernelTestCase
 
         $renderer = static::getContainer()->get('storybook.story_renderer');
 
-        $story = new Story('story', '<twig:ComponentUsingTrait />', new Args());
+        $story = new Story('story', 'story.html.twig', '<twig:ComponentUsingTrait />', new Args());
 
         $content = $renderer->render($story);
 
@@ -187,8 +187,8 @@ class StoryRendererTest extends KernelTestCase
 
         $renderer = static::getContainer()->get('storybook.story_renderer');
 
-        $storyWithFunction = new Story('story', '<twig:AnonymousComponent :prop1="prop1"/>', new Args(['prop1' => 'foo']));
-        $storyWithTag = new Story('story', '<twig:AnonymousComponent :prop1="prop1"></twig:AnonymousComponent>', new Args(['prop1' => 'foo']));
+        $storyWithFunction = new Story('story', 'story.html.twig', '<twig:AnonymousComponent :prop1="prop1"/>', new Args(['prop1' => 'foo']));
+        $storyWithTag = new Story('story', 'story.html.twig', '<twig:AnonymousComponent :prop1="prop1"></twig:AnonymousComponent>', new Args(['prop1' => 'foo']));
 
         $this->assertEquals($renderer->render($storyWithFunction), $renderer->render($storyWithTag));
     }
@@ -199,7 +199,7 @@ class StoryRendererTest extends KernelTestCase
 
         $renderer = static::getContainer()->get('storybook.story_renderer');
 
-        $story = new Story('story', '<twig:AnonymousComponent foo="bar"></twig:AnonymousComponent>', new Args());
+        $story = new Story('story', 'story.html.twig', '<twig:AnonymousComponent foo="bar"></twig:AnonymousComponent>', new Args());
 
         $this->assertStringContainsString('foo="bar"', $renderer->render($story));
     }

--- a/tests/Unit/StoryRendererTest.php
+++ b/tests/Unit/StoryRendererTest.php
@@ -29,6 +29,7 @@ class StoryRendererTest extends TestCase
 
         $story = new Story(
             'story',
+            'story.html.twig',
             '',
             new Args()
         );
@@ -51,6 +52,7 @@ class StoryRendererTest extends TestCase
 
         $story = new Story(
             'story',
+            'story.html.twig',
             '',
             new Args()
         );

--- a/tests/Unit/Util/StorybookAttributesTest.php
+++ b/tests/Unit/Util/StorybookAttributesTest.php
@@ -7,12 +7,38 @@ use Storybook\Util\StorybookAttributes;
 
 class StorybookAttributesTest extends TestCase
 {
-    public function testCreateFromArray()
+    /**
+     * @dataProvider getValidArguments
+     */
+    public function testCreateFromArray(array $array, StorybookAttributes $expected)
     {
-        $attributes = StorybookAttributes::from(['story' => 'story']);
+        $attributes = StorybookAttributes::from($array);
 
-        $this->assertInstanceOf(StorybookAttributes::class, $attributes);
-        $this->assertEquals('story', $attributes->story);
+        $this->assertEquals($expected, $attributes);
+    }
+
+    public static function getValidArguments(): iterable
+    {
+        yield 'only story' => [
+            'array' => [
+                'story' => 'story',
+            ],
+            'expected' => new StorybookAttributes(
+                'story',
+                null
+            ),
+        ];
+
+        yield 'with template name' => [
+            'array' => [
+                'story' => 'story',
+                'template' => 'story.html.twig',
+            ],
+            'expected' => new StorybookAttributes(
+                'story',
+                'story.html.twig'
+            ),
+        ];
     }
 
     public function testCreateFromInvalidArrayThrowsException()


### PR DESCRIPTION
Fix live component cache error when rendering with embedded strategy in the main story template. 

Because the main story template is created at runtime, and may changes at each render, we can't cache it to the disk. However, when live components are rendered using the embedded syntax, they need the parent template to get the top level context. Because we know this context doesn't matter when rendering the story, we can safely ignore it.