### PR TITLE
fix: avoid 'SandboxExtension is already registered' error

### DIFF
--- a/src/Twig/StorybookEnvironmentConfigurator.php
+++ b/src/Twig/StorybookEnvironmentConfigurator.php
@@ -30,9 +30,13 @@ final class StorybookEnvironmentConfigurator
         $this->inner->configure($environment);
 
         $environment->setCache($this->cacheDir);
+        $registeredExtensions = $environment->getExtensions();
 
         foreach ($this->extensions as $extension) {
-            $environment->addExtension($extension);
+            $extensionClass = get_class($extension);
+            if (!isset($registeredExtensions[$extensionClass])) {
+                $environment->addExtension($extension);
+            }
         }
     }
 }


### PR DESCRIPTION
When using this bundle with Pimcore 11.* and Symfony 6.4, users may encounter the error 'SandboxExtension is already registered' during template rendering. This issue arises because the extension is being added multiple times.

Solution:
This pull request ensures that the SandboxExtension is added only if it has not already been loaded, preventing duplicate registrations and resolving the error.